### PR TITLE
[RHOAIENG-7286] - Update go lang and base image

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,5 +1,5 @@
-#go-toolset:1.21
-FROM registry.redhat.io/ubi8/go-toolset:1.21@sha256:742ae6ec1aef3e7faae488c47695fb64964d342aefecf52d23bd9d5e6731d0b6 AS build
+# Builder
+FROM registry.redhat.io/ubi9/go-toolset:1.22.9@sha256:6402ad7886fb3bdaa950c89bdf338f8dbedde54c16bddb1157ebb8691b2def50 AS build
 
 LABEL image="build"
 
@@ -17,7 +17,8 @@ COPY . ./
 # Build the binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o /go/bin/server ./proxy/
 
-#ubi-micro
+###############################################################################
+# Runtime - ubi-micro
 FROM registry.access.redhat.com/ubi8/ubi-micro@sha256:eae27ba458e682d6d830f6c77c9e3a4c33cf1718461397b741e674d9d37450f3 as runtime
 
 ARG USER=2000

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Builder
-FROM registry.redhat.io/ubi9/go-toolset:1.22.9@sha256:6402ad7886fb3bdaa950c89bdf338f8dbedde54c16bddb1157ebb8691b2def50 AS build
+FROM registry.redhat.io/ubi9/go-toolset:1.22@sha256:4a3e5c7ed37cc4a2b44dccbebc44766f4144ff31776e6ff51ded85df2a21d72b AS build
 
 LABEL image="build"
 


### PR DESCRIPTION
chore:	Update Go Lang from 1.21 to 1.22.9
	Update base image from UBI8 to UBI9