### PR TITLE
RHOAIENG-19618: [rhoai-2.20] Bump Go to 1.23 (#52)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ###############################################################################
 # Stage 1: Create the developer image for the BUILDPLATFORM only
 ###############################################################################
-ARG GOLANG_VERSION=1.22
+ARG GOLANG_VERSION=1.23
 FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS develop
 
 ARG PROTOC_VERSION=21.12

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Builder
-FROM registry.redhat.io/ubi9/go-toolset:1.22@sha256:e4193e71ea9f2e2504f6b4ee93cadef0fe5d7b37bba57484f4d4229801a7c063 AS build
+FROM registry.redhat.io/ubi9/go-toolset:1.23@sha256:8a634d63713a073d7a1e086a322e57b148eef9620834fc8266df63d9294dff1b AS build
 
 LABEL image="build"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/rest-proxy
 
-go 1.22.9
+go 1.23.6
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Fix CVE `CVE-2025-22866`.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>