### PR TITLE
chore(deps): updates ubi9/go-toolset

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Builder
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22@sha256:e4193e71ea9f2e2504f6b4ee93cadef0fe5d7b37bba57484f4d4229801a7c063 AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23@sha256:2a88121395084eaa575e5758b903fffb43dbf9d9586b2878e51678f63235b587 AS build
 
 LABEL image="build"
 


### PR DESCRIPTION
Updated registry.access.redhat.com/ubi9/go-toolset:1.22@sha256:e4193e71ea9f2e2504f6b4ee93cadef0fe5d7b37bba57484f4d4229801a7c063 to registry.access.redhat.com/ubi9/go-toolset:1.23@sha256:2a88121395084eaa575e5758b903fffb43dbf9d9586b2878e51678f63235b587.