### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-mm-rest-proxy-v2-20

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -24,7 +24,8 @@ FROM registry.access.redhat.com/ubi8/ubi-micro@sha256:084c06bf84ceb8ed8f868bd27e
 ARG USER=2000
 
 LABEL com.redhat.component="odh-mm-rest-proxy-container" \
-      name="managed-open-data-hub/odh-mm-rest-proxy-rhel8" \
+      name="rhoai/odh-mm-rest-proxy-rhel8" \
+      cpe="cpe:/a:redhat:openshift_ai:2.20::el8" \
       description="Converts RESTfull API calls into gRPC" \
       summary="odh-mm-rest-proxy" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
