### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-mm-rest-proxy-v2-19

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -23,7 +23,8 @@ FROM registry.access.redhat.com/ubi8/ubi-micro@sha256:0b348ff16700e13fef3753b712
 ARG USER=2000
 
 LABEL com.redhat.component="odh-mm-rest-proxy-container" \
-      name="managed-open-data-hub/odh-mm-rest-proxy-rhel8" \
+      name="rhoai/odh-mm-rest-proxy-rhel8" \
+      cpe="cpe:/a:redhat:openshift_ai:2.19::el8" \
       description="Converts RESTfull API calls into gRPC" \
       summary="odh-mm-rest-proxy" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
