### PR TITLE
chore: use floating tags insted of digest

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Builder
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:35f08031de19eb51d6b35ed62c6357d3529bc69a8db65cf623ea5f0b44051999 AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS build
 
 LABEL image="build"
 
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} GO111MODUL
 
 ###############################################################################
 # Runtime - ubi-micro
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:7d4e47500f28ac3a2bff06c25eff9127ff21048538ae03ce240d57cf756acd00 as runtime
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as runtime
 
 ARG USER=2000
 


### PR DESCRIPTION
As title tells, to use a standard across serving-related repositories.

Related to https://redhat.atlassian.net/browse/RHOAIENG-54583