### PR TITLE
[RHOAIENG-73981] upgrade golang to 1.26

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Builder
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS build
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS build
 
 LABEL image="build"
 


### PR DESCRIPTION
chore:  Upgrade GoLang to 1.26 to fix Go net package: Denial of Service via long CNAME response in LookupCNAME